### PR TITLE
chore: disable multiarch server image build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Build and push image
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: ${{ !github.event.pull_request.head.repo.fork }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
It's awfully slow, I'll add back a proper (fast) build for it at some point later